### PR TITLE
cache improvements

### DIFF
--- a/MicroBlog/MicroBlog/Services/UserAccountsService.cs
+++ b/MicroBlog/MicroBlog/Services/UserAccountsService.cs
@@ -78,7 +78,7 @@ public class UserAccountsService : IUserAccountsService
             {
                 await Task.Delay(redactionSimulationTime);
                 await _userAccountsCollection.ReplaceOneAsync(x => x.Id == id, updatedUserAccount);
-                await _redisDb.StringSetAsync(id, JsonSerializer.Serialize(updatedUserAccount));
+                await _redisDb.KeyDeleteAsync(id);
                 if (!await _redisDb.LockReleaseAsync(lockId, LockIdentifier))
                 {
                     Console.WriteLine($"Cannot unlock the lock,\nUserAccount={id},\nLockId={lockId}");
@@ -94,8 +94,6 @@ public class UserAccountsService : IUserAccountsService
         { 
             // replace in the mongo db
             await _userAccountsCollection.ReplaceOneAsync(x => x.Id == id, updatedUserAccount);
-            // set in redis
-            await _redisDb.StringSetAsync(id, JsonSerializer.Serialize(updatedUserAccount));
         }
     }
 


### PR DESCRIPTION
Реализовал следующие улучшения для кэша:
- удаляю запись по ключу при редактировании
- убрал запись в кэш в ветке else.
Есть вопрос:
"Тоже самое если его нет в кэше при редактировании, можно даже этот кейс не проверять, всё равно при get запросе, пользователь закэшируется. " - Здесь имеется в виду, что при редактировании, то есть в методе UserAccountsController.Update, мы уже вызываем _userAccountsService.GetAsync, тем самым при редактировании он уже гарантировано в кэше?
